### PR TITLE
Update pom for release process

### DIFF
--- a/fdahpStudyDesigner/pom.xml
+++ b/fdahpStudyDesigner/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.fdahpstudydesigner</groupId>
 	<artifactId>fdahpStudyDesigner</artifactId>
-	<version>21.3.0-SNAPSHOT</version>
+	<version>21.3-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>fdahpStudyDesigner</name>
 	<description>Studies Gateway Web Application</description>


### PR DESCRIPTION
The standard LabKey versioning doesn't include the patch number in SNAPSHOT version numbers. Updating the version number here to be consistent.