### PR TITLE
remove jdbc:mysql string from db.url and add enabledTLSProtocols=TLSv1.2

### DIFF
--- a/template_application.properties
+++ b/template_application.properties
@@ -21,14 +21,14 @@ signUp.url=http://localhost:8080/fdahpStudyDesigner/signUp.do?securityToken=
 #Database Configuration
 #<<--------------------------------Replace ‘localhost:3306’ according to your database application configuration------------------------>>
 #here 3306 is mysql port number
-db.url=jdbc:mysql://localhost:3306/fda_hphc?autoReconnect=true&sslMode=PREFERRED
+db.url=localhost:3306/fda_hphc?autoReconnect=true&sslMode=PREFERRED&enabledTLSProtocols=TLSv1.2
 db.username=<your database username>
 db.password=<your database password>
 
 #Hibernate Database Configuration for WCP-WS 
 #<<--------------------------------Replace ‘localhost:3306’ according to your database application configuration------------------------>>
 #here 3306 is mysql port number
-hibernate.connection.url=jdbc:mysql://localhost:3306/fda_hphc?autoReconnect=true&sslMode=PREFERRED
+hibernate.connection.url=jdbc:mysql://localhost:3306/fda_hphc?autoReconnect=true&sslMode=PREFERRED&enabledTLSProtocols=TLSv1.2
 hibernate.connection.username=<your database username>
 hibernate.connection.password=<your database password>
 


### PR DESCRIPTION
- update db.url to remove jdbc:mysql:// string - with this string the server reports malformed db url on startup. 
- update db.url and hibernate.connection.url to add enabledTLSProtocols=TLSv1.2 to enable TLSv1.2 protocol as TLSv1 and TLSv1.1 protocols are deprecated in Java releases since April 2021.